### PR TITLE
# 5. User story: Find by status

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@ import {
   complete,
   findById,
   findByTitle,
+  findByStatus,
 } from './todo.js';
 import { display } from './display.js';
 import { AppError } from './app-error.js';
@@ -13,6 +14,7 @@ import {
   validateAddParams,
   validateFindByIdParam,
   validateFindByTitleParam,
+  validateStatusParam,
 } from './validate.js';
 
 export function createApp(todoStore, args) {
@@ -55,6 +57,12 @@ export function createApp(todoStore, args) {
       }
       const completed = complete(todoStore, id);
       display(['Todo completed:', format(completed)]);
+      break;
+
+    case 'find-by-status':
+      const validatedStatusParam = validateStatusParam(params);
+      const todosList = findByStatus(todoStore, validatedStatusParam);
+      console.log(todosList);
       break;
 
     default:

--- a/src/todo.js
+++ b/src/todo.js
@@ -36,14 +36,10 @@ export function add(store, params) {
 
 export function findById(store, params) {
   const [id] = params;
-  const idIsNotNumber = isNaN(+id);
-
-  if (idIsNotNumber) {
-    throw new AppError('Id is not a number, please provide a number');
-  }
   const todoList = store.get();
 
   const matchingTodoItem = todoList.find((todo) => todo.id === +id);
+
   if (!matchingTodoItem) {
     throw new AppError(`Todo with id: ${id}, is not found!`);
   }
@@ -66,4 +62,10 @@ export function complete(store, id) {
   todo.done = true;
   store.set(todos);
   return todo;
+}
+
+export function findByStatus(store, status) {
+  const todos = store.get();
+  const isDone = status === 'done';
+  return todos.filter((todo) => todo.done === isDone);
 }

--- a/src/todo.spec.js
+++ b/src/todo.spec.js
@@ -1,5 +1,14 @@
 import { jest } from '@jest/globals';
-import { add, findById, findByTitle, format, formatList, list, complete } from './todo.js';
+import {
+  add,
+  findById,
+  findByTitle,
+  format,
+  formatList,
+  list,
+  complete,
+  findByStatus,
+} from './todo.js';
 import { AppError } from './app-error.js';
 
 function createMockStore(data) {
@@ -188,7 +197,7 @@ describe('findByTitle', () => {
   it('should find a todo by its title', () => {
     const mockStore = createMockStore([
       { id: 1, title: 'Todo 1', done: false },
-      { id: 2, title: 'Todo 2', done: true }
+      { id: 2, title: 'Todo 2', done: true },
     ]);
 
     const current = findByTitle(mockStore, 'Todo 1');
@@ -200,7 +209,7 @@ describe('findByTitle', () => {
   it('should return null when the todo does not exist', () => {
     const mockStore = createMockStore([
       { id: 1, title: 'Todo 1', done: false },
-      { id: 2, title: 'Todo 2', done: true }
+      { id: 2, title: 'Todo 2', done: true },
     ]);
 
     const current = findByTitle(mockStore, 'Todo 3');
@@ -225,7 +234,58 @@ describe('complete', () => {
     const current = complete(mockStore, 1);
 
     expect(current).toStrictEqual({ id: 1, title: 'Todo 1', done: true });
-    expect(mockStore.set.mock.calls[0][0])
-      .toStrictEqual([{ id: 1, title: 'Todo 1', done: true }]);
+    expect(mockStore.set.mock.calls[0][0]).toStrictEqual([
+      { id: 1, title: 'Todo 1', done: true },
+    ]);
+  });
+});
+
+describe('find-by-status', () => {
+  it('should pass with a done todos list', () => {
+    const [params] = ['done'];
+    const mockStore = createMockStore([
+      {
+        id: 1,
+        done: true,
+        title: 'Read a book.',
+      },
+      {
+        id: 2,
+        done: false,
+        title: 'do the dishes.',
+      },
+    ]);
+
+    const expected = [
+      {
+        id: 1,
+        done: true,
+        title: 'Read a book.',
+      },
+    ];
+    const current = findByStatus(mockStore, params);
+
+    expect(current).toStrictEqual(expected);
+  });
+
+  it('should return an empty list', () => {
+    const [params] = ['done'];
+    const mockStore = createMockStore([
+      {
+        id: 1,
+        done: false,
+        title: 'Read a book.',
+      },
+      {
+        id: 2,
+        done: false,
+        title: 'do the dishes.',
+      },
+    ]);
+
+    const expected = [];
+    const current = findByStatus(mockStore, params);
+
+    expect(current).toStrictEqual(expected);
   });
 });

--- a/src/todo.spec.js
+++ b/src/todo.spec.js
@@ -140,22 +140,6 @@ describe('add', () => {
 });
 
 describe('findById', () => {
-  it('should throw an error because the param is not a number', () => {
-    const params = ['kiskutya'];
-    const mockStore = createMockStore([
-      {
-        id: 1,
-        done: false,
-        title: 'Read a book.',
-      },
-    ]);
-
-    expect(() => findById(mockStore, params)).toThrow(AppError);
-    expect(() => findById(mockStore, params)).toThrowError(
-      'Id is not a number, please provide a number'
-    );
-  });
-
   it('should throw an error because the todo item is not found', () => {
     const params = ['2'];
     const [id] = params;

--- a/src/validate.js
+++ b/src/validate.js
@@ -33,3 +33,16 @@ export function validateFindByTitleParam(params) {
 
   return params;
 }
+
+export function validateStatusParam(params) {
+  const [statusParam] = params;
+  const validSearchStrings = ['done', 'not-done'];
+  if (
+    typeof statusParam !== 'string' ||
+    !validSearchStrings.includes(statusParam)
+  ) {
+    throw new AppError("Status have to be 'done' or 'not-done' string!");
+  }
+
+  return statusParam;
+}

--- a/src/validate.spec.js
+++ b/src/validate.spec.js
@@ -3,6 +3,7 @@ import {
   validateAddParams,
   validateFindByIdParam,
   validateFindByTitleParam,
+  validateStatusParam,
 } from './validate';
 
 describe('validateAddParams', () => {
@@ -120,6 +121,35 @@ describe('validateFindByTitleParam', () => {
     expect(() => validateFindByTitleParam(params)).toThrow(AppError);
     expect(() => validateFindByTitleParam(params)).toThrow(
       'The title should be string and at least 3 charachter long!'
+    );
+  });
+});
+
+describe('validateStatusParam', () => {
+  it('should pass and return the original params with a valid status', () => {
+    const params = ['done'];
+    const expected = 'done';
+
+    const validated = validateStatusParam(params);
+
+    expect(validated).toStrictEqual(expected);
+  });
+
+  it('should throw an error if try with another status which not exist', () => {
+    const params = ['pending'];
+
+    expect(() => validateStatusParam(params)).toThrow(AppError);
+    expect(() => validateStatusParam(params)).toThrow(
+      "Status have to be 'done' or 'not-done' string!"
+    );
+  });
+
+  it('should throw an error when no params are given', () => {
+    const params = [];
+
+    expect(() => validateStatusParam(params)).toThrow(AppError);
+    expect(() => validateStatusParam(params)).toThrow(
+      "Status have to be 'done' or 'not-done' string!"
     );
   });
 });


### PR DESCRIPTION
## 5. User story: Find by status

As a user I can filter my todos by done / not done status, 
so I can review my progress or check my remaining tasks.

- A new command 'find-by-status' is added to the app.
- It has one parameter a string "done" or "not-done". Show a meaningful error message to the user, if not one of these two strings given, or no string given.
- Display the todos with the given status only to the user, or a meaningful message (not error) if there is no todos found with that status.
- Cover the new functionality with tests.