### PR TITLE
impl show label on todos

### DIFF
--- a/src/todo.js
+++ b/src/todo.js
@@ -1,7 +1,11 @@
 import { AppError } from './app-error.js';
 
 export function format(todo) {
-  return `${todo.id} - [${todo.done ? 'x' : ' '}] ${todo.title}`;
+  const labels =
+    todo.labels && todo.labels.length > 0
+      ? `(${todo.labels.join(', ')})`
+      : '(no labels)';
+  return `${todo.id} - [${todo.done ? 'x' : ' '}] ${labels} ${todo.title}`;
 }
 
 export function formatList(todos) {

--- a/src/todo.spec.js
+++ b/src/todo.spec.js
@@ -19,18 +19,69 @@ function createMockStore(data) {
 }
 
 describe('format', () => {
-  it('should format a not done todo', () => {
+  it('should format a not done todo without labels key', () => {
     const todo = { title: 'todo title', id: 1, done: false };
-    const expected = '1 - [ ] todo title';
+    const expected = '1 - [ ] (no labels) todo title';
 
     const current = format(todo);
 
     expect(current).toStrictEqual(expected);
   });
 
-  it('should format a done todo', () => {
+  it('should format a done todo without labels key', () => {
     const todo = { title: 'todo title', id: 1, done: true };
-    const expected = '1 - [x] todo title';
+    const expected = '1 - [x] (no labels) todo title';
+
+    const current = format(todo);
+
+    expect(current).toStrictEqual(expected);
+  });
+
+  it('should format a not done todo with an empty labels array', () => {
+    const todo = {
+      title: 'todo title',
+      id: 1,
+      done: false,
+      labels: [],
+    };
+    const expected = '1 - [ ] (no labels) todo title';
+
+    const current = format(todo);
+
+    expect(current).toStrictEqual(expected);
+  });
+
+  it('should format a done todo with an empty labels array', () => {
+    const todo = {
+      title: 'todo title',
+      id: 1,
+      done: true,
+      labels: [],
+    };
+    const expected = '1 - [x] (no labels) todo title';
+
+    const current = format(todo);
+
+    expect(current).toStrictEqual(expected);
+  });
+
+  it('should format a not done todo with labels present', () => {
+    const todo = {
+      title: 'todo title',
+      id: 1,
+      done: false,
+      labels: ['urgent', 'home'],
+    };
+    const expected = '1 - [ ] (urgent, home) todo title';
+
+    const current = format(todo);
+
+    expect(current).toStrictEqual(expected);
+  });
+
+  it('should format a done todo with labels present', () => {
+    const todo = { title: 'todo title', id: 1, done: true, labels: ['work'] };
+    const expected = '1 - [x] (work) todo title';
 
     const current = format(todo);
 
@@ -44,7 +95,10 @@ describe('formatList', () => {
       { title: 'todo title', id: 1, done: true },
       { title: 'todo title 2', id: 2, done: false },
     ];
-    const expected = ['1 - [x] todo title', '2 - [ ] todo title 2'];
+    const expected = [
+      '1 - [x] (no labels) todo title',
+      '2 - [ ] (no labels) todo title 2',
+    ];
 
     const current = formatList(todos);
 


### PR DESCRIPTION
change the format method in todo.js as requirments details
goal is to show as : `<ID> - [< x or " ">] (<labels>) <title>`.
- add labels with comma delimited in parentheses before the title

add two new scenarios to the tests to the format.js so it is with full coverage after change on the method
- done with labels 
- not done with labels
- done without labels key
- not done without labels key
- done with empty array as labels key
- not done with empty array as labels key